### PR TITLE
fix: gigantic blog __data.json

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,5 +29,17 @@ export default ts.config(
 	},
 	{
 		ignores: ['build/', '.svelte-kit/', 'dist/']
+	},
+	{
+		rules: {
+			'@typescript-eslint/no-unused-vars': [
+				'warn',
+				{
+					argsIgnorePattern: '^_',
+					varsIgnorePattern: '^_',
+					caughtErrorsIgnorePattern: '^_'
+				}
+			]
+		}
 	}
 );

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,9 +6,9 @@
 	import '../theme/variables.scss';
 	import '../theme/hr.scss';
 
-    import { onMount } from 'svelte';
-    import { initAnalytics } from '$lib/services/analytics.services.js';
-    import Header from '$lib/components/header.svelte';
+	import { onMount } from 'svelte';
+	import { initAnalytics } from '$lib/services/analytics.services.js';
+	import Header from '$lib/components/header.svelte';
 	import Footer from '$lib/components/footer.svelte';
 
 	let { children } = $props();

--- a/src/routes/blog/+page.server.ts
+++ b/src/routes/blog/+page.server.ts
@@ -2,7 +2,7 @@ import { listBlog } from '$lib/plugins/blog.plugin';
 import type { BlogMetadata } from '$lib/types/blog';
 import type { MarkdownData } from '$lib/types/markdown';
 
-export const load = async (): Promise<{ posts: MarkdownData<BlogMetadata>[] }> => {
+export const load = async (): Promise<{ posts: Omit<MarkdownData<BlogMetadata>, 'content'>[] }> => {
 	const posts = await listBlog();
-	return { posts };
+	return { posts: posts.map(({ content: _, ...rest }) => rest) };
 };

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -11,7 +11,7 @@
 	}
 
 	let { data }: Props = $props();
-	let posts: MarkdownData<BlogMetadata>[] = $derived(data.posts);
+	let posts: Omit<MarkdownData<BlogMetadata>, 'content'>[] = $derived(data.posts);
 </script>
 
 <svelte:head>


### PR DESCRIPTION
`__data.json` are kind of mandatory on SvelteKit https://github.com/sveltejs/kit/discussions/8847#discussioncomment-4854826

As a result the one file at the root of Blob became super big 2MB

Excluding content reduce massively the size