### PR TITLE
feat: add head meta site.standard.publication with workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 	"scripts": {
 		"assets": "bun serve.assets.ts",
 		"dev": "vite dev",
-		"build": "vite build",
+		"build:workaround": "node svelte.workaround.ts",
+		"build": "vite build && pnpm build:workaround",
 		"package": "svelte-kit package",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync",

--- a/src/app.html
+++ b/src/app.html
@@ -23,11 +23,10 @@
 			type="application/rss+xml"
 		/>
 		<meta name="google-site-verification" content="MN7tFl4-DoVbSEs95kr28GSJK6FO_9Ub-lMW2h51ZjM" />
-		<!-- TODO: SvelteKit build bug Invalid URL -->
-		<!--link
-			rel="site.standard.publication"
+		<link
+			rel="site.standard.publication external"
 			href="at://did:plc:fxmgj7lnas3ewnc3hmpx2vg6/site.standard.publication/3mnjy5srkem2h"
-		/-->
+		/>
 		%sveltekit.head%
 	</head>
 	<body>

--- a/svelte.workaround.ts
+++ b/svelte.workaround.ts
@@ -1,0 +1,22 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { extname, join } from 'node:path';
+
+// TODO: a workaround for SvelteKit issue https://github.com/sveltejs/kit/issues/15935
+
+const output = join(process.cwd(), 'build');
+const files = await readdir(output, { recursive: true });
+const htmlFiles = files.filter((file) => extname(file) === '.html');
+
+const update = async (fileRelativePath: string) => {
+	const filePath = join(output, fileRelativePath);
+	const content = await readFile(filePath, 'utf8');
+	const cleanedContent = content.replaceAll(
+		'site.standard.publication external',
+		'site.standard.publication'
+	);
+	await writeFile(filePath, cleanedContent, 'utf-8');
+};
+
+await Promise.all(htmlFiles.map(update));
+
+console.log('✅ Meta tag site.standard.publication updated.');


### PR DESCRIPTION
Workaround relates to https://github.com/sveltejs/kit/issues/15935